### PR TITLE
Add layer undo and WrongNames support

### DIFF
--- a/ToolbarMain.py
+++ b/ToolbarMain.py
@@ -1,10 +1,13 @@
 import os
 import sys
 import json
-
+import importlib
 
 BASE_DIR = os.path.dirname(__file__)
 sys.path.insert(0, BASE_DIR)
+
+import lodkitfilter
+importlib.reload(lodkitfilter)
 
 from lodkitfilter import (
     apply_filter_from_button_states,

--- a/nametags.json
+++ b/nametags.json
@@ -1,6 +1,12 @@
 {
     "groups": [
         "base",
-        "stock"
+        "restyle",
+        "restyleunified",
+        "rim",
+        "sport",
+        "sportline",
+        "stock",
+        "yurol"
     ]
 }


### PR DESCRIPTION
## Summary
- track created layers and restore originals
- move objects with bad names to **WrongNames**
- add a command to create layers without enabling the filter
- wire up the new command to the `btnMakeLayers` button

## Testing
- `python -m py_compile ToolbarMain.py lodkitfilter.py`

------
https://chatgpt.com/codex/tasks/task_e_6842b38f4e2c832e88504d130cae9c2d