### PR TITLE
Optimize LOD filter operations

### DIFF
--- a/lodkitfilter.py
+++ b/lodkitfilter.py
@@ -1,6 +1,8 @@
 import os
 import json
 import re
+import time
+from contextlib import contextmanager
 import pymxs
 from pymxs import runtime as rt
 
@@ -19,6 +21,27 @@ _LOD_RE = re.compile(r'^(?:lod|l)(\d+)_([^_]+)_', re.I)
 _created_layers = set()
 _track_created = False
 
+
+@contextmanager
+def scene_redraw_off():
+    """Temporarily disable scene redraw for bulk operations."""
+    try:
+        rt.disableSceneRedraw()
+        yield
+    finally:
+        rt.enableSceneRedraw()
+
+
+def profile_time(func):
+    """Decorator to measure execution time of heavy functions."""
+    def wrapper(*args, **kwargs):
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        duration = time.perf_counter() - start
+        print(f"{func.__name__} took {duration:.3f}s")
+        return result
+    return wrapper
+
 def load_variants():
     if not os.path.exists(GROUP_TAGS_PATH):
         return []
@@ -26,9 +49,10 @@ def load_variants():
         data = json.load(f)
     return [v.lower() for v in data.get('groups', [])]
 
+@profile_time
 def collect_scene_variants():
     variants = set()
-    for obj in rt.objects:
+    for obj in list(rt.objects):
         if not rt.isValidNode(obj):
             continue
         _, variant = parse_name(obj.name)
@@ -36,6 +60,7 @@ def collect_scene_variants():
             variants.add(variant)
     return sorted(variants)
 
+@profile_time
 def save_variants():
     tags = collect_scene_variants()
     with open(GROUP_TAGS_PATH, 'w') as f:
@@ -67,18 +92,32 @@ def record_original_layer(obj):
         except Exception:
             pass
 
+@profile_time
 def restore_original_layers():
     lm = rt.LayerManager
+    layer_cache = {}
+    nodes_by_layer = {}
+
     for handle, layer_name in list(_original_layers.items()):
         node = rt.maxOps.getNodeByHandle(handle)
-        if node and rt.isValidNode(node):
+        if not (node and rt.isValidNode(node)):
+            continue
+        lyr = layer_cache.get(layer_name)
+        if lyr is None:
             lyr = lm.getLayerFromName(layer_name)
-            if lyr:
+            layer_cache[layer_name] = lyr
+        if lyr:
+            nodes_by_layer.setdefault(lyr, []).append(node)
+
+    with scene_redraw_off():
+        for lyr, nodes in nodes_by_layer.items():
+            for node in nodes:
                 lyr.addNode(node)
                 try:
                     node.isHidden = not bool(getattr(lyr, 'on', True))
                 except Exception:
                     pass
+
     _original_layers.clear()
 
 def _sync_layer_objects_visibility(layer):
@@ -96,23 +135,18 @@ def _sync_layer_objects_visibility(layer):
     except Exception:
         pass
 
+@profile_time
 def build_structure(variants, assign_wrong=True):
-    """
-    Оптимизированная версия build_structure.
-    """
+    """Create LOD layers and assign objects in bulk."""
     lm = rt.LayerManager
-    parent_layers = {}
+    parent_layers = {v: get_or_create_layer(v) for v in variants}
     lod_layers = {}
-    nodes_by_layer = {}  # Слой -> [объекты]
+    nodes_by_layer = {}
     wrong_nodes = []
-
-    # Создаём родительские слои один раз
-    for variant in variants:
-        parent_layers[variant] = get_or_create_layer(variant)
     wrong_layer = get_or_create_layer("WrongNames") if assign_wrong else None
 
-    # Сначала группируем объекты по слоям в памяти
-    for obj in rt.objects:
+    # Сначала собираем информацию об объектах
+    for obj in list(rt.objects):
         if not rt.isValidNode(obj):
             continue
         lod, variant = parse_name(obj.name)
@@ -121,53 +155,66 @@ def build_structure(variants, assign_wrong=True):
                 record_original_layer(obj)
                 wrong_nodes.append(obj)
             continue
+
         record_original_layer(obj)
         lod_layer_name = f"{variant}_LOD{lod}"
         if lod_layer_name not in lod_layers:
-            lod_layers[lod_layer_name] = get_or_create_layer(lod_layer_name)
-            # Устанавливаем родителя только один раз
-            if hasattr(lod_layers[lod_layer_name], 'setParent'):
-                lod_layers[lod_layer_name].setParent(parent_layers[variant])
+            lod_layer = get_or_create_layer(lod_layer_name)
+            lod_layers[lod_layer_name] = lod_layer
+            if hasattr(lod_layer, 'setParent'):
+                lod_layer.setParent(parent_layers[variant])
         nodes_by_layer.setdefault(lod_layer_name, []).append(obj)
 
-    # Только теперь назначаем объекты слоям одним bulk-ом
-    for layer_name, nodes in nodes_by_layer.items():
-        lyr = lod_layers[layer_name]
-        if hasattr(lyr, 'addNode'):
+    # Массовое назначение объектов слоям и синхронизация видимости
+    with scene_redraw_off():
+        for layer_name, nodes in nodes_by_layer.items():
+            lyr = lod_layers[layer_name]
             for obj in nodes:
                 lyr.addNode(obj)
 
-    if assign_wrong and wrong_layer:
-        for obj in wrong_nodes:
-            wrong_layer.addNode(obj)
+        if assign_wrong and wrong_layer:
+            for obj in wrong_nodes:
+                wrong_layer.addNode(obj)
 
-    # Видимость синхронизируем только по одному разу
-    for layer in parent_layers.values():
-        _sync_layer_objects_visibility(layer)
-    for layer in lod_layers.values():
-        _sync_layer_objects_visibility(layer)
-    if wrong_layer:
-        _sync_layer_objects_visibility(wrong_layer)
+        for layer in parent_layers.values():
+            _sync_layer_objects_visibility(layer)
+        for layer in lod_layers.values():
+            _sync_layer_objects_visibility(layer)
+        if wrong_layer:
+            _sync_layer_objects_visibility(wrong_layer)
+
     rt.redrawViews()
 
 
 
 
+@profile_time
 def apply_visibility(button_states, variants):
     lm = rt.LayerManager
+    layer_cache = {}
+    layer_visibility = {}
+
+    # Подготавливаем список слоёв и желаемую видимость
     for variant in variants:
-        var_btn = button_states.get(f"btnVar_{variant}", True)
+        var_visible = button_states.get(f"btnVar_{variant}", True)
         var_layer = lm.getLayerFromName(variant)
         if var_layer:
-            var_layer.on = var_btn
-            _sync_layer_objects_visibility(var_layer)
+            layer_visibility[var_layer] = var_visible
+            layer_cache[variant] = var_layer
         for i in range(4):
-            lod_layer = lm.getLayerFromName(f"{variant}_LOD{i}")
-            visible = var_btn and button_states.get(f"btnL{i}", False)
-            if lod_layer:
-                lod_layer.on = visible
-                _sync_layer_objects_visibility(lod_layer)
+            name = f"{variant}_LOD{i}"
+            layer = lm.getLayerFromName(name)
+            if layer:
+                layer_visibility[layer] = var_visible and button_states.get(f"btnL{i}", False)
+                layer_cache[name] = layer
 
+    with scene_redraw_off():
+        for layer, state in layer_visibility.items():
+            layer.on = state
+        for layer in layer_visibility:
+            _sync_layer_objects_visibility(layer)
+
+@profile_time
 def apply_filter_from_button_states(button_states):
     """Update layer visibility according to UI states."""
     if not button_states.get('chkEnableFilter', False):
@@ -178,6 +225,7 @@ def apply_filter_from_button_states(button_states):
     rt.redrawViews()
 
 
+@profile_time
 def enable_filter():
     """Parse variants, create layers and record assignments."""
     global _current_variants, _track_created
@@ -189,28 +237,37 @@ def enable_filter():
     rt.redrawViews()
 
 
+@profile_time
 def disable_filter():
     """Restore nodes to their original layers and reset layer visibility."""
     global _track_created
     with pymxs.undo(True):
         restore_original_layers()
         lm = rt.LayerManager
+
+        layers_to_show = []
         for variant in list(_current_variants):
+            pl = lm.getLayerFromName(variant)
+            if pl:
+                layers_to_show.append(pl)
             for i in range(4):
                 lyr = lm.getLayerFromName(f"{variant}_LOD{i}")
                 if lyr:
-                    lyr.on = True
-                    _sync_layer_objects_visibility(lyr)
-            pl = lm.getLayerFromName(variant)
-            if pl:
-                pl.on = True
-                _sync_layer_objects_visibility(pl)
+                    layers_to_show.append(lyr)
+
+        with scene_redraw_off():
+            for lyr in layers_to_show:
+                lyr.on = True
+            for lyr in layers_to_show:
+                _sync_layer_objects_visibility(lyr)
+
         _created_layers.clear()
         _current_variants.clear()
         _track_created = False
     rt.redrawViews()
 
 
+@profile_time
 def make_layers():
     """Create LOD layers without enabling the filter."""
     global _track_created


### PR DESCRIPTION
## Summary
- add profiling decorator and context manager for scene redraw
- group lookups and assignments in `build_structure`, `restore_original_layers`, `apply_visibility`
- add profiling to heavy operations
- reduce repeated layer manager calls and bulk layer updates

## Testing
- `python -m py_compile *.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bfb9e0b4832e914c7b095fe1e508